### PR TITLE
'make pngs'-fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,17 +72,12 @@ pokecrystal.gbc: $(crystal_obj)
 	rgblink -n $*.sym -m $*.map -o $@ $^
 	rgbfix -Cjv -i BYTE -k 01 -l 0x33 -m 0x10 -p 0 -r 3 -t PM_CRYSTAL $@
 
-compress := gfx/trainers/beauty
-compress2 := gfx/pics/egg/front
-
 
 pngs:
-#	-exec $(gfx) unlz $(compress2).2bpp.lz
-#	-exec $(gfx) png $(compress2).2bpp
 	find . -iname "*.lz"      -exec $(gfx) unlz {} +
 	find . -iname "*.[12]bpp" -exec $(gfx) png  {} +
-#	find . -iname "*.[12]bpp" -exec touch {} +
-#	find . -iname "*.lz"      -exec touch {} +
+	find . -iname "*.[12]bpp" -exec touch {} +
+	find . -iname "*.lz"      -exec touch {} +
 
 %.2bpp: %.png ; $(gfx) 2bpp $<
 %.1bpp: %.png ; $(gfx) 1bpp $<

--- a/Makefile
+++ b/Makefile
@@ -72,12 +72,17 @@ pokecrystal.gbc: $(crystal_obj)
 	rgblink -n $*.sym -m $*.map -o $@ $^
 	rgbfix -Cjv -i BYTE -k 01 -l 0x33 -m 0x10 -p 0 -r 3 -t PM_CRYSTAL $@
 
+compress := gfx/trainers/beauty
+compress2 := gfx/pics/egg/front
+
 
 pngs:
+#	-exec $(gfx) unlz $(compress2).2bpp.lz
+#	-exec $(gfx) png $(compress2).2bpp
 	find . -iname "*.lz"      -exec $(gfx) unlz {} +
 	find . -iname "*.[12]bpp" -exec $(gfx) png  {} +
-	find . -iname "*.[12]bpp" -exec touch {} +
-	find . -iname "*.lz"      -exec touch {} +
+#	find . -iname "*.[12]bpp" -exec touch {} +
+#	find . -iname "*.lz"      -exec touch {} +
 
 %.2bpp: %.png ; $(gfx) 2bpp $<
 %.1bpp: %.png ; $(gfx) 1bpp $<

--- a/gfx.py
+++ b/gfx.py
@@ -19,7 +19,6 @@ def filepath_rules(filepath):
 	filedir, filename = os.path.split(filepath)
 	name, ext = os.path.splitext(filename)
 
-	
 	if 'gfx/pics/' in filedir:
 		if name == 'front':
 			args['pal_file'] = os.path.join(filedir, 'normal.pal')
@@ -41,7 +40,7 @@ def filepath_rules(filepath):
 				w = min(w/8, h/8)
 				args['pic_dimensions'] = w, w
 			else:
-				args['pic_dimensions'] = 7, 6
+				args['pic_dimensions'] = 6, 6
 
 	elif 'gfx/trainers' in filedir:
 		if ext == '.png':

--- a/gfx.py
+++ b/gfx.py
@@ -19,29 +19,58 @@ def filepath_rules(filepath):
 	filedir, filename = os.path.split(filepath)
 	name, ext = os.path.splitext(filename)
 
+	
 	if 'gfx/pics/' in filedir:
+		#print("test2 %s") % filename
 		if name == 'front':
 			args['pal_file'] = os.path.join(filedir, 'normal.pal')
-			args['pic'] = True
-			args['animate'] = True
+			if os.path.exists(os.path.join(filedir, 'normal.pal')) != True:
+				args['pal_file'] = None
+			#args['pic'] = True
+			#args['animate'] = True
+			if ext == '.png':
+				w, h = gfx.png.Reader(filepath).asRGBA8()[:2]
+				w = min(w/8, h/8)
+				args['pic_dimensions'] = w, w
+			else:
+				args['pic_dimensions'] = 7, 7
 		elif name == 'back':
-			args['pal_file'] = os.path.join(filedir, 'shiny.pal')
-			args['pic'] = True
+			args['pal_file'] = os.path.join(filedir, 'normal.pal') #shiny.pal
+			if os.path.exists(os.path.join(filedir, 'normal.pal')) != True:
+				args['pal_file'] = None
+			#args['pic'] = True
+			if ext == '.png':
+				w, h = gfx.png.Reader(filepath).asRGBA8()[:2]
+				w = min(w/8, h/8)
+				args['pic_dimensions'] = w, w
+			else:
+				args['pic_dimensions'] = 7, 6
 
 	elif 'gfx/trainers' in filedir:
-		args['pic'] = True
+		#print("test3")
+		#args['pic'] = True
+		if ext == '.png':
+			w, h = gfx.png.Reader(filepath).asRGBA8()[:2]
+			args['width'] = w
+			args['height'] = h
+			w = min(w/8, h/8)
+			args['pic_dimensions'] = w, w
+		else:
+			args['pic_dimensions'] = 7, 7
 
 	elif os.path.join(filedir, name) in pics:
 		args['pic'] = True
 
-	if args.get('pal_file'):
-		args['palout'] = args['pal_file']
+#	if args.get('pal_file'):
+#		args['palout'] = args['pal_file']
 
-	if args.get('pic'):
-		if ext == '.png':
-			w, h = gfx.png.Reader(filepath).asRGBA8()[:2]
-			w = min(w/8, h/8)
-			args['pic_dimensions'] = w, w
+	#if args.get('pic'):
+	#	if ext == '.png':
+	#		w, h = gfx.png.Reader(filepath).asRGBA8()[:2]
+	#		w = min(w/8, h/8)
+	#		args['pic_dimensions'] = w, w
+	#args['pic_dimensions'] = 7, 7
+	#print "w = %i" % (w)
 	return args
 
 

--- a/gfx.py
+++ b/gfx.py
@@ -21,12 +21,10 @@ def filepath_rules(filepath):
 
 	
 	if 'gfx/pics/' in filedir:
-		#print("test2 %s") % filename
 		if name == 'front':
 			args['pal_file'] = os.path.join(filedir, 'normal.pal')
 			if os.path.exists(os.path.join(filedir, 'normal.pal')) != True:
 				args['pal_file'] = None
-			#args['pic'] = True
 			#args['animate'] = True
 			if ext == '.png':
 				w, h = gfx.png.Reader(filepath).asRGBA8()[:2]
@@ -38,7 +36,6 @@ def filepath_rules(filepath):
 			args['pal_file'] = os.path.join(filedir, 'normal.pal') #shiny.pal
 			if os.path.exists(os.path.join(filedir, 'normal.pal')) != True:
 				args['pal_file'] = None
-			#args['pic'] = True
 			if ext == '.png':
 				w, h = gfx.png.Reader(filepath).asRGBA8()[:2]
 				w = min(w/8, h/8)
@@ -47,8 +44,6 @@ def filepath_rules(filepath):
 				args['pic_dimensions'] = 7, 6
 
 	elif 'gfx/trainers' in filedir:
-		#print("test3")
-		#args['pic'] = True
 		if ext == '.png':
 			w, h = gfx.png.Reader(filepath).asRGBA8()[:2]
 			args['width'] = w
@@ -63,14 +58,6 @@ def filepath_rules(filepath):
 
 #	if args.get('pal_file'):
 #		args['palout'] = args['pal_file']
-
-	#if args.get('pic'):
-	#	if ext == '.png':
-	#		w, h = gfx.png.Reader(filepath).asRGBA8()[:2]
-	#		w = min(w/8, h/8)
-	#		args['pic_dimensions'] = w, w
-	#args['pic_dimensions'] = 7, 7
-	#print "w = %i" % (w)
 	return args
 
 


### PR DESCRIPTION
I've fixed the 'gfx.py'-file so that we can use 'make pngs' now.
The main problem was that variabes like 'args['pic']' were set and then the functions in extras/gfx.py were called, which didn't expect this variable and throw errors.

The resulting pictures aren't correct, yet. The interleaving doesn't work everywhere correctly. I fixed it for the folder 'gfx/trainers' and for 'gfx/pics' (but only for the 1st part of the animation in the front.png-picture = the upper part of the picture).
for example gfx/pics/ampharos/front.png: ![front](https://cloud.githubusercontent.com/assets/13925587/9559232/810ac49e-4df0-11e5-8008-4b2248877c89.png)
And it also seems that the width of the picture is different for every Pkmn, that's the reason why not every front.png-picture looks right.
The palette for both Pkmn-pictures is now the normal one. The back-picture was created before with the shiny-palette.

I don't have tested if the pictures are now correctly compressed and converted back to the GBC. Since I've made a few changes, it shouldn't give the correct result.